### PR TITLE
Rename DOCKER_PASSWORD secret reference to DOCKER_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
Aligns this repo with the rest of `anarkiwi/*` which uses `DOCKER_TOKEN` for Docker Hub auth. The PR is a pure rename — workflow logic is unchanged.

**Prereq:** `DOCKER_TOKEN` repo secret must exist (you've added it). After merge, delete the old `DOCKER_PASSWORD` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)