### PR TITLE
Reduce nuisance workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: docker-release
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
 jobs:
   jetson-pytorch:
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
## Summary

Tag-gate `docker-release` workflow so it only fires on push to main and `v*` tags. Previously fired on every push and `pull_request`, so every Dependabot/Renovate PR attempted a release run that fails because secrets aren't available to the `release` environment on PRs.

## Test plan

- [ ] On a follow-up PR, no `docker-release` runs are created.