### PR TITLE
Decouple image tag from pytorch version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,24 @@ jobs:
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-      - name: Change for main
-        id: change_version
-        run: if [ "${{ steps.get_version.outputs.VERSION }}" == "main" ]; then echo ::set-output name=VERSION::latest; else echo ::set-output name=VERSION::${{ steps.get_version.outputs.VERSION }}; fi
+      # The image tag and the pytorch git ref are not the same thing:
+      # main publishes :latest, and "latest" is not a pytorch ref. Take
+      # the ref from the Dockerfile's own default so there is one place
+      # to bump.
+      - name: Resolve versions
+        id: version
+        run: |
+          set -eu
+          if [ "$GITHUB_REF_TYPE" = tag ]; then
+            image_tag="$GITHUB_REF_NAME"
+            torch_ref="$GITHUB_REF_NAME"
+          else
+            image_tag=latest
+            torch_ref=$(sed -n 's/^ARG PYTORCH_VERSION="\(.*\)"$/\1/p' Dockerfile.pytorch)
+          fi
+          test -n "$torch_ref"
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+          echo "torch_ref=$torch_ref" >> "$GITHUB_OUTPUT"
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -35,9 +47,9 @@ jobs:
           file: Dockerfile.pytorch
           platforms: linux/arm64
           push: true
-          tags: anarkiwi/jetson-pytorch:${{ steps.change_version.outputs.VERSION }}
+          tags: anarkiwi/jetson-pytorch:${{ steps.version.outputs.image_tag }}
           build-args: |
-            PYTORCH_VERSION=${{ steps.change_version.outputs.VERSION }}
+            PYTORCH_VERSION=${{ steps.version.outputs.torch_ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
         if: github.repository == 'anarkiwi/jetson-pytorch' && github.event_name == 'push'


### PR DESCRIPTION
Every `main` build of `docker-release` has failed since at least 2026-05-19 — including the JetPack 7.2 merge ([run 30598189831](https://github.com/anarkiwi/jetson-pytorch/actions/runs/30598189831)), which died 82s in, before reaching any of the changed content:

```
#10 [pytorch-builder 4/8] RUN ... git clone --depth 1 --recursive --branch latest http://github.com/pytorch/pytorch
#10 0.676 fatal: Remote branch latest not found in upstream origin
```

The workflow collapsed two different things into one value. On `main` the image tag is rewritten `main` → `latest`, and that same string was passed as `PYTORCH_VERSION` — but `latest` is not a pytorch branch or tag. Only tag builds ever worked, because there the two happen to coincide.

This resolves them independently:

- **tag push** — image tag and pytorch ref both come from the tag (unchanged behaviour).
- **main push** — image tag is `latest`; pytorch ref is read from `Dockerfile.pytorch`'s own `ARG PYTORCH_VERSION` default, so bumping the release stays a one-line Dockerfile edit rather than a second place to keep in sync.

Also swaps the deprecated `set-output` (which GitHub warns is being disabled) for `$GITHUB_OUTPUT`, and drops the redundant `$GITHUB_REF` string-slicing in favour of `$GITHUB_REF_NAME` / `$GITHUB_REF_TYPE`.

Merging this makes the next `main` build actually exercise the JetPack 7.2 / CUDA 13.2.1 base at pytorch v2.13.0 — the first real signal on that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm