### PR TITLE
Give the build headroom under the 6h job limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,16 @@ jobs:
           test -n "$torch_ref"
           echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           echo "torch_ref=$torch_ref" >> "$GITHUB_OUTPUT"
+      # 4 concurrent nvcc jobs on a 16 GB runner can spike past RAM on
+      # the heaviest ATen template units. Swap turns that from an
+      # OOM-kill into a brief slowdown.
+      - name: Add swap
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:

--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -21,7 +21,17 @@ WORKDIR /pytorch
 RUN pip install --no-cache-dir $PIP_OPTS -r /pytorch/requirements.txt
 # 8.7 is Orin (sm_87); still supported by CUDA 13, unlike the sm_5x-7x
 # archs it dropped.
-RUN MAX_JOBS=2 USE_PRIORITIZED_TEXT_FOR_LD=1 TORCH_CUDA_ARCH_LIST="8.7" BUILD_IGNORE_SVE_UNAVAILABLE=1 python3 /pytorch/setup.py bdist_wheel
+#
+# MAX_JOBS defaults to the 4 vCPUs of the ubuntu-24.04-arm runner.
+# MAX_JOBS=2 dated from when triton built in this same image and its
+# LLVM link stage set the memory ceiling; triton now lives in
+# anarkiwi/jetson-triton, so the other half of the runner is free.
+# BUILD_TEST=0 drops the C++ test binaries, which never reach the
+# wheel. Together these buy the margin the 6h job limit needs: every
+# successful build from v2.10.0 to v2.12.0 landed at 321-344 min, and
+# v2.13.0 was killed at the 360 min ceiling.
+ARG MAX_JOBS=4
+RUN MAX_JOBS=${MAX_JOBS} USE_PRIORITIZED_TEXT_FOR_LD=1 TORCH_CUDA_ARCH_LIST="8.7" BUILD_TEST=0 BUILD_IGNORE_SVE_UNAVAILABLE=1 python3 /pytorch/setup.py bdist_wheel
 
 # Release stage stays on the devel base: anarkiwi/jetson-triton compiles
 # triton against this image and needs nvcc plus the CUDA/cuDNN headers.


### PR DESCRIPTION
The v2.13.0 build on `main` was killed by GitHub's 6h job limit ([run 30598770512](https://github.com/anarkiwi/jetson-pytorch/actions/runs/30598770512), `The job has exceeded the maximum execution time of 6h0m0s`).

That is **not** a JetPack 7 regression. Every successful build has been running just under the wire:

| tag | result | duration |
|---|---|---|
| v2.10.0 | success | 333 min |
| v2.10.0 | success | 321 min |
| v2.11.0 | success | 344 min |
| v2.12.0 | success | 331 min |
| v2.13.0 | **timeout** | 360 min (killed) |

89–96% of the ceiling, consistently. Retrying would just re-roll the same dice, so this buys margin instead.

## Changes

- **`MAX_JOBS` 2 → 4** (now a build arg). The `ubuntu-24.04-arm` runner is 4 vCPU / 16 GB, so half of it was idle. `MAX_JOBS=2` dates from when triton built inside this same image and its LLVM link stage set the memory ceiling — that moved to `anarkiwi/jetson-triton`, so the constraint no longer applies. Exposing it as an arg lets a bigger local host go higher.
- **`BUILD_TEST=0`**. The C++ test binaries are compiled and then discarded; they never reach the wheel.
- **8G swapfile on the runner.** 4 concurrent nvcc jobs can spike past 16 GB on the heaviest ATen template units. Swap converts that from an OOM-kill into a brief slowdown — the failure mode that would otherwise make `MAX_JOBS=4` a gamble.

Parallelism doesn't scale linearly and I can't measure this without spending a build, so treat the estimate as an estimate: roughly half the compile wall-clock, plus whatever `BUILD_TEST=0` removes. The point is to stop sitting at 95% of the limit, not to hit a specific number.

If `MAX_JOBS=4` still OOMs through swap, 3 is the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm