### PR TITLE
Put the extra swapfile somewhere the runner is not already using

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,17 @@ jobs:
       # 4 concurrent nvcc jobs on a 16 GB runner can spike past RAM on
       # the heaviest ATen template units. Swap turns that from an
       # OOM-kill into a brief slowdown.
+      # The runner already has an active /swapfile, so this adds a
+      # second area rather than replacing it -- Linux takes as many as
+      # you give it.
       - name: Add swap
         run: |
-          sudo fallocate -l 8G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          set -eu
+          sudo fallocate -l 8G "$RUNNER_TEMP/swapfile"
+          sudo chmod 600 "$RUNNER_TEMP/swapfile"
+          sudo mkswap "$RUNNER_TEMP/swapfile"
+          sudo swapon "$RUNNER_TEMP/swapfile"
+          swapon --show
           free -h
       - name: Login to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
Follow-up to #23. The `Add swap` step failed in under a second and skipped the build ([run 30624578628](https://github.com/anarkiwi/jetson-pytorch/actions/runs/30624578628)):

```
fallocate: fallocate failed: Text file busy
```

The `ubuntu-24.04-arm` runner already ships with an active `/swapfile`, so allocating over it was never going to work — my mistake in #23.

Allocate in `$RUNNER_TEMP` instead and leave the runner's own area alone. Linux takes multiple swap areas, so this is additive rather than a replacement, and there's no need to `swapoff` anything first. Also logs `swapon --show` and `free -h` so the actual result is visible in the next run instead of being assumed.

`MAX_JOBS=4` / `BUILD_TEST=0` from #23 are untouched and still unexercised — this is what lets them actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm