### PR TITLE
Restore runtime deps the l4t-jetpack base used to supply, and test for it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         if: github.repository == 'anarkiwi/jetson-pytorch' && github.event_name == 'push'
+      # The runner is arm64, so the pushed image runs natively here. No
+      # GPU, so this proves packaging only -- that the wheel imports and
+      # carries the arch it was meant to.
+      - name: Smoke test pushed image
+        run: docker run --rm anarkiwi/jetson-pytorch:${{ steps.version.outputs.image_tag }} python3 /smoke_test.py
+        if: github.repository == 'anarkiwi/jetson-pytorch' && github.event_name == 'push'

--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -36,10 +36,16 @@ RUN MAX_JOBS=${MAX_JOBS} USE_PRIORITIZED_TEXT_FOR_LD=1 TORCH_CUDA_ARCH_LIST="8.7
 # Release stage stays on the devel base: anarkiwi/jetson-triton compiles
 # triton against this image and needs nvcc plus the CUDA/cuDNN headers.
 FROM nvcr.io/nvidia/cuda:${CUDA_BASE}
-RUN apt-get -yq update && apt-get install -yq git python3-pip python3-dev libopenmpi3t64 libopenblas0
+# libnuma1: libc10.so links it, so `import torch` fails without it.
+# The builder gets it transitively from libopenmpi-dev; the l4t-jetpack
+# base used to carry it, the stock CUDA base does not.
+RUN apt-get -yq update && apt-get install -yq git python3-pip python3-dev libopenmpi3t64 libopenblas0 libnuma1
 ARG PIP_OPTS=""
 ENV PIP_OPTS=$PIP_OPTS
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ENV CUDA_HOME=/usr/local/cuda
 WORKDIR /
-RUN --mount=type=bind,from=pytorch-builder,source=/pytorch/dist,target=/pytorch/dist pip install --no-cache-dir $PIP_OPTS /pytorch/dist/*whl
+# numpy is not a hard torch dependency but torch warns and disables its
+# numpy interop without it; the l4t-jetpack base shipped it.
+RUN --mount=type=bind,from=pytorch-builder,source=/pytorch/dist,target=/pytorch/dist pip install --no-cache-dir $PIP_OPTS numpy /pytorch/dist/*whl
+COPY smoke_test.py /smoke_test.py

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,41 @@
+"""Post-build check that the image is usable off-Jetson.
+
+Everything here runs without an NVIDIA driver, so CI on a GPU-less runner
+catches packaging faults before the image ships. GPU execution needs real
+hardware; torch.cuda.is_available() is deliberately not asserted.
+"""
+
+import sys
+
+import numpy
+import torch
+
+EXPECTED_ARCHS = ["sm_87"]  # Orin
+EXPECTED_CUDA_MAJOR = "13"
+
+
+def main() -> int:
+    """Report what the image carries and assert it is coherent."""
+    print(f"python  {sys.version.split()[0]}")
+    print(f"torch   {torch.__version__}")
+    print(f"cuda    {torch.version.cuda}")
+    print(f"cudnn   {torch.backends.cudnn.version()}")
+    print(f"archs   {torch.cuda.get_arch_list()}")
+    print(f"numpy   {numpy.__version__}")
+
+    assert torch.cuda.get_arch_list() == EXPECTED_ARCHS, torch.cuda.get_arch_list()
+    assert torch.version.cuda.split(".")[0] == EXPECTED_CUDA_MAJOR, torch.version.cuda
+    assert torch.backends.cudnn.version() is not None
+
+    # ATen kernels the wheel was built with, plus the numpy bridge.
+    x = torch.randn(64, 64)
+    assert x.mm(x).shape == (64, 64)
+    assert numpy.allclose(x.numpy(), x.detach().cpu().numpy())
+    assert torch.from_numpy(numpy.eye(4, dtype="float32")).sum().item() == 4.0
+
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The v2.13.0 build went green in 2h52m and published an image where `import torch` fails:

```
ImportError: libnuma.so.1: cannot open shared object file: No such file or directory
```

`libc10.so` links libnuma. The builder stage picks it up transitively from `libopenmpi-dev`, and `l4t-jetpack` carried it in the release image, so moving to the stock CUDA/Ubuntu base silently dropped it. `numpy` went the same way — not a hard torch dependency, but torch warns and disables its numpy interop without it.

Rather than fix the one symptom and re-roll a 3h build to find the next, I scanned every `torch/lib/*.so` for unresolved sonames:

```
libc10.so:            libnuma.so.1
libcaffe2_nvrtc.so:   libcuda.so.1
```

`libcuda.so.1` is the driver stub — absent off-Jetson by design, injected by the container runtime on real hardware. So `libnuma1` + `numpy` closes it.

## Testing the class of fault, not just this instance

Adds `smoke_test.py`, run against the **pushed** image. The runner is arm64, so the published artifact executes natively — no QEMU. With no GPU it proves packaging rather than execution, which is precisely what broke here: the wheel imports, carries `sm_87`, was built against CUDA 13.x, has cuDNN, does a matmul, and round-trips through numpy.

Verified against a patched copy of the published image:

```
python  3.12.3
torch   2.13.0a0+gitcf30153
cuda    13.2
cudnn   92000
archs   ['sm_87']
numpy   2.5.1
OK
```

`torch.cuda.is_available()` is deliberately not asserted — real GPU function still needs Orin hardware, and this cannot substitute for that.

Black clean, pylint 10.00.

## Separately worth noting

The wheel reports `2.13.0a0+gitcf30153`, not `2.13.0` — the Dockerfile never sets `PYTORCH_BUILD_VERSION`, so setup.py falls back to an alpha label. Pre-existing, not from the JetPack 7 port, but it means a consumer pinning `torch>=2.13` won't match. Left alone here; happy to fix in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm