### PR TITLE
Drop compat_orin so the image starts under the nvidia runtime

### DIFF
--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -48,4 +48,11 @@ WORKDIR /
 # numpy is not a hard torch dependency but torch warns and disables its
 # numpy interop without it; the l4t-jetpack base shipped it.
 RUN --mount=type=bind,from=pytorch-builder,source=/pytorch/dist,target=/pytorch/dist pip install --no-cache-dir $PIP_OPTS numpy /pytorch/dist/*whl
-COPY smoke_test.py /smoke_test.py
+COPY smoke_test.py gpu_test.py /
+# The CUDA 13.2 image carries an Orin forward-compat driver here, which
+# nvidia-container-toolkit 1.19.1 panics parsing, so no container using
+# the nvidia runtime starts at all -- stock nvcr.io/nvidia/cuda
+# included. JetPack 7.2 already ships a newer driver (595.78 vs the
+# 595.58.03 in compat_orin), so these libraries are dead weight on the
+# host this image targets.
+RUN rm -rf /usr/local/cuda/compat_orin

--- a/README.md
+++ b/README.md
@@ -46,7 +46,20 @@ Push a `vX.Y.Z` tag matching the pytorch release; the
 
 ## Sanity check
 
+`smoke_test.py` runs without a driver and gates CI on packaging;
+`gpu_test.py` needs a real Orin and checks CUDA against CPU
+references. Both ship in the image.
+
 ```bash
-docker run --rm --runtime nvidia anarkiwi/jetson-pytorch:v2.13.0 \
-    python3 -c "import torch; print(torch.__version__, torch.cuda.is_available())"
+docker run --rm anarkiwi/jetson-pytorch:v2.13.0 python3 /smoke_test.py
+docker run --rm --runtime nvidia anarkiwi/jetson-pytorch:v2.13.0 python3 /gpu_test.py
 ```
+
+The release stage deletes `/usr/local/cuda/compat_orin`, the Orin
+forward-compat driver the CUDA base ships.
+nvidia-container-toolkit 1.19.1 panics parsing it, which stops any
+container using the nvidia runtime from starting -- stock
+`nvcr.io/nvidia/cuda` included. It is redundant here anyway: JetPack
+7.2's driver is newer than the compat libraries. The cost is that
+this image needs a JetPack 7.2-class driver (R595+) rather than
+carrying its own fallback.

--- a/gpu_test.py
+++ b/gpu_test.py
@@ -1,0 +1,42 @@
+"""On-device check that CUDA actually executes, for a real Jetson.
+
+Complements smoke_test.py, which deliberately runs without a driver so
+GPU-less CI can gate packaging. Run this on an Orin under the nvidia
+runtime; it fails on any host without a working GPU.
+"""
+
+import sys
+
+import torch
+from torch import nn
+
+EXPECTED_CAPABILITY = (8, 7)  # Orin
+
+
+def main() -> int:
+    """Exercise CUDA and cuDNN against CPU references."""
+    assert torch.cuda.is_available(), "no CUDA device visible"
+    props = torch.cuda.get_device_properties(0)
+    print(f"device  {props.name} sm_{props.major}{props.minor}")
+    print(f"memory  {props.total_memory // 1024 ** 2} MB")
+    print(f"driver  {torch.version.cuda}")
+
+    assert (props.major, props.minor) == EXPECTED_CAPABILITY, props
+
+    a, b = torch.randn(512, 512), torch.randn(512, 512)
+    assert torch.allclose(a @ b, (a.cuda() @ b.cuda()).cpu(), atol=1e-3)
+
+    conv = nn.Conv2d(3, 16, 3)
+    x = torch.randn(8, 3, 64, 64)
+    assert torch.backends.cudnn.is_available()
+    assert torch.allclose(conv(x), conv.cuda()(x.cuda()).cpu(), atol=1e-4)
+
+    half = torch.randn(256, 256, device="cuda", dtype=torch.float16)
+    assert (half @ half).shape == (256, 256)
+
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Tested on a real JetPack 7.2 Orin Nano. The published image — which passed CI — **could not start at all** under `--runtime nvidia`:

```
error running createContainer hook #2: exit status 2, stderr:
panic: runtime error: slice bounds out of range [:73] with capacity 71
  nvidia-cdi-hook/cudacompat.GetCUDACompatElfHeaderFromReader (cuda-elf-header.go:86)
  cudacompat.useCompatLibraries (cudacompat.go:197)
```

## Root cause

`nvidia-container-toolkit` 1.19.1 panics parsing the Orin forward-compat driver that the CUDA 13.2 image ships in `/usr/local/cuda/compat_orin`. The CDI spec points the hook there (`--cuda-compat-container-root=/usr/local/cuda/compat_orin`), it fails to read the ELF header, and the container never initialises.

Stock `nvcr.io/nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04` fails **identically**, so this is not something the JetPack 7 port introduced — but it does make every image built on that base unusable under the nvidia runtime.

## Fix

Delete the directory in the release stage. The libraries are redundant on the host this image targets: JetPack 7.2 carries driver **595.78**, newer than the **595.58.03** in `compat_orin`, and forward compatibility is precisely what they exist for.

The cost, stated plainly: the image now needs an R595+ driver instead of carrying its own fallback for older ones. That matches the host requirements the README already documents.

Alternatives considered — a host-side `disable-cuda-compat-lib-hook` in `config.toml`, or a newer toolkit — both work but require every consumer to change their host. This keeps the image self-sufficient.

## Verified on orinnano (L4T r39.2, driver 595.78, toolkit 1.19.1)

```
available True
device Orin sm_87 mem_MB 7546
matmul allclose True
cudnn conv (8, 16, 62, 62)
cudnn enabled True
fp16 matmul (256, 256)
GPU OK
```

## gpu_test.py

Adds the on-device counterpart to `smoke_test.py`: CUDA matmul and cuDNN convolution both checked against CPU references, compute capability asserted as sm_87.

CI has no GPU and structurally could not have caught this — the image passed every check and was still dead on the target hardware. This is what to run on real hardware before trusting a release. Black clean, pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm