### PR TITLE
Report a release version, not 2.13.0a0+gitcf30153

### DIFF
--- a/Dockerfile.pytorch
+++ b/Dockerfile.pytorch
@@ -30,8 +30,17 @@ RUN pip install --no-cache-dir $PIP_OPTS -r /pytorch/requirements.txt
 # wheel. Together these buy the margin the 6h job limit needs: every
 # successful build from v2.10.0 to v2.12.0 landed at 321-344 min, and
 # v2.13.0 was killed at the 360 min ceiling.
+#
+# pytorch's version.txt carries an alpha marker (2.13.0a0) and setup.py
+# appends +git<sha> unless PYTORCH_BUILD_VERSION says otherwise, so a
+# tag build would otherwise ship 2.13.0a0+gitcf30153 and sort below
+# 2.13.0 for anyone pinning torch>=2.13. PYTORCH_BUILD_NUMBER is
+# mandatory alongside it. The guard keeps non-tag refs building: the
+# version is PEP 440 validated, so exporting a branch name would fail.
 ARG MAX_JOBS=4
-RUN MAX_JOBS=${MAX_JOBS} USE_PRIORITIZED_TEXT_FOR_LD=1 TORCH_CUDA_ARCH_LIST="8.7" BUILD_TEST=0 BUILD_IGNORE_SVE_UNAVAILABLE=1 python3 /pytorch/setup.py bdist_wheel
+ARG PYTORCH_BUILD_NUMBER=1
+RUN case "${PYTORCH_VERSION}" in v[0-9]*) export PYTORCH_BUILD_VERSION="${PYTORCH_VERSION#v}" PYTORCH_BUILD_NUMBER="${PYTORCH_BUILD_NUMBER:-1}" ;; esac; \
+    MAX_JOBS=${MAX_JOBS} USE_PRIORITIZED_TEXT_FOR_LD=1 TORCH_CUDA_ARCH_LIST="8.7" BUILD_TEST=0 BUILD_IGNORE_SVE_UNAVAILABLE=1 python3 /pytorch/setup.py bdist_wheel
 
 # Release stage stays on the devel base: anarkiwi/jetson-triton compiles
 # triton against this image and needs nvcc plus the CUDA/cuDNN headers.

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -12,6 +12,7 @@ import torch
 
 EXPECTED_ARCHS = ["sm_87"]  # Orin
 EXPECTED_CUDA_MAJOR = "13"
+DEV_VERSION_MARKERS = ("a0", "+git")  # only a branch build should carry these
 
 
 def main() -> int:
@@ -26,6 +27,11 @@ def main() -> int:
     assert torch.cuda.get_arch_list() == EXPECTED_ARCHS, torch.cuda.get_arch_list()
     assert torch.version.cuda.split(".")[0] == EXPECTED_CUDA_MAJOR, torch.version.cuda
     assert torch.backends.cudnn.version() is not None
+
+    # 2.13.0a0+gitcf30153 sorts below 2.13.0, defeating a torch>=2.13 pin.
+    assert not any(
+        m in torch.__version__ for m in DEV_VERSION_MARKERS
+    ), torch.__version__
 
     # ATen kernels the wheel was built with, plus the numpy bridge.
     x = torch.randn(64, 64)


### PR DESCRIPTION
The image built from the `v2.13.0` tag reports `torch.__version__ == "2.13.0a0+gitcf30153"`. Under PEP 440 that sorts **below** `2.13.0`, so a consumer pinning `torch>=2.13` does not match it.

## Cause

`version.txt` at the v2.13.0 tag contains `2.13.0a0` — upstream leaves the alpha marker in the tree and injects the real version at build time. `tools/generate_torch_version.py`:

```python
if os.getenv("PYTORCH_BUILD_VERSION"):
    if os.getenv("PYTORCH_BUILD_NUMBER") is None:
        raise AssertionError("PYTORCH_BUILD_NUMBER must be set when PYTORCH_BUILD_VERSION is set")
    ...
else:
    version = Path(pytorch_root / "version.txt").read_text().strip()
    version += "+git" + sha[:7]
```

This image never set those, so it always took the fallback. Pre-existing — every tag back to v2.9.1 shipped the same way.

## Fix

Derive the version from the tag already being passed in:

```dockerfile
ARG PYTORCH_BUILD_NUMBER=1
RUN case "${PYTORCH_VERSION}" in v[0-9]*) export PYTORCH_BUILD_VERSION="${PYTORCH_VERSION#v}" PYTORCH_BUILD_NUMBER="${PYTORCH_BUILD_NUMBER:-1}" ;; esac; \
    MAX_JOBS=${MAX_JOBS} ... python3 /pytorch/setup.py bdist_wheel
```

`PYTORCH_BUILD_NUMBER` is mandatory, not optional — setup.py raises without it.

The `case` guard is load-bearing: the version is PEP 440 validated, so exporting a branch name would fail the build outright. Verified across every ref form:

```
PYTORCH_VERSION=v2.13.0    -> BUILD_VERSION=[2.13.0]
PYTORCH_VERSION=v2.14.0    -> BUILD_VERSION=[2.14.0]
PYTORCH_VERSION=main       -> BUILD_VERSION=[unset]
PYTORCH_VERSION=abc1234    -> BUILD_VERSION=[unset]
PYTORCH_VERSION=<empty>    -> BUILD_VERSION=[unset]
```

Tag builds get `2.13.0`; branch builds keep the `+git` suffix, which is correct for them.

Result: `torch.__version__ == "2.13.0"`, wheel becomes `torch-2.13.0-cp312-cp312-linux_aarch64.whl`.

## Regression guard

`smoke_test.py` now rejects `a0` / `+git` markers. This is exactly the class of defect that stays invisible unless something asserts on it — it survived five releases unnoticed.

## Cost

**A full ~2h52m recompile.** The build `RUN` line changes, invalidating the cached compile layer. There is no way to fix the version stamp without rebuilding the wheel.

Requires a retag of `v2.13.0` afterwards to publish a corrected versioned image; `latest` updates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWcispBMQno3TvKycAnWEm